### PR TITLE
Don't stringify formatter output data when it is already a primitive …

### DIFF
--- a/index.js
+++ b/index.js
@@ -156,7 +156,11 @@ ManifestRevisionPlugin.prototype.apply = function (compiler) {
             outputData = self.options.format(data, parsedAssets);
         }
 
-        fs.writeFileSync(output, JSON.stringify(outputData));
+        if (typeof outputData === 'object') {
+            outputData = JSON.stringify(outputData);
+        }
+
+        fs.writeFileSync(output, String(outputData));
     });
 };
 


### PR DESCRIPTION
Currently it is only possible to return a js object from the formatter. This breaks when you want to create a file (like a browserconfig.xml) that is not a json file.

This pull request solves the problem by only calling `JSON.stringify` when the return type from the formatter is an Object or Array.