### PR TITLE
Exclude *hot-update.js* files from output

### DIFF
--- a/format.js
+++ b/format.js
@@ -25,6 +25,9 @@ Format.prototype.normalizeChunks = function () {
             output[chunk] = chunkValue;
         }
         else {
+            chunkValue = chunkValue.filter(function(item) {
+                return item.indexOf('hot-update.js') === -1;
+            });
             output[chunk] = chunkValue.slice(-1)[0];
         }
     }

--- a/tests/fixtures/rawStats.js
+++ b/tests/fixtures/rawStats.js
@@ -5,6 +5,9 @@ var rawStats = {
     publicPath: 'http://localhost:2992/assets/',
     assetsByChunkName: {
         app_js: 'app_js.5018c3226e10bf313701.js',
+        hot_app_js: ['app_js.5018c3226e10bf313701.js',
+            '2.aa80015de0a5a07f7481.hot-update.js'
+        ],
         app_css: ['app_css.291431bdd7415f9ff51d.js',
             'app_css.291431bdd7415f9ff51d.css'
         ]

--- a/tests/formatTest.js
+++ b/tests/formatTest.js
@@ -13,6 +13,8 @@ function test_general() {
 
     assert.equal(data.assets['app_js.js'],
                  'app_js.5018c3226e10bf313701.js');
+    assert.equal(data.assets['hot_app_js.js'],
+                 'app_js.5018c3226e10bf313701.js');
     assert.equal(data.assets['app_css.css'],
                  'app_css.291431bdd7415f9ff51d.css');
     assert.equal(data.assets['images/spinner.gif'],


### PR DESCRIPTION
This change excludes the webpack *hot-update.js* files from the plugin output to address the hot reloading issue in the flask-webpack project: https://github.com/nickjj/flask-webpack/issues/2

I realize this fix is very specific. Not sure if it should be generalized or if there is a better place to put it.