### PR TITLE
Fix multiple files chunks

### DIFF
--- a/format.js
+++ b/format.js
@@ -22,13 +22,13 @@ Format.prototype.normalizeChunks = function () {
         var chunkValue = this.data.assetsByChunkName[chunk];
 
         if (typeof chunkValue === 'string') {
-            output[chunk] = chunkValue;
+            output[chunk] = [chunkValue];
         }
         else {
             chunkValue = chunkValue.filter(function(item) {
                 return item.indexOf('hot-update.js') === -1;
             });
-            output[chunk] = chunkValue.slice(-1)[0];
+            output[chunk] = chunkValue;
         }
     }
 
@@ -47,10 +47,13 @@ Format.prototype.mergeChunksIntoAssets = function () {
     output.assets = this.assets;
 
     for (var chunk in assetsByChunkName) {
-        var fileExtension = assetsByChunkName[chunk].split('.').slice(-1)[0];
-        var chunkWithExtension = chunk + '.' + fileExtension;
+        for (var asset in assetsByChunkName[chunk]) {
+            asset = assetsByChunkName[chunk][asset]
+            var fileExtension = asset.split('.').slice(-1)[0];
+            var chunkWithExtension = chunk + '.' + fileExtension;
 
-        output.assets[chunkWithExtension] = assetsByChunkName[chunk];
+            output.assets[chunkWithExtension] = asset;
+        }
     }
 
     return output;
@@ -74,7 +77,7 @@ Format.prototype.general = function () {
 Format.prototype.rails = function () {
     var output = this.general();
     output.files = {};
-    
+
     for (var asset in this.assets) {
         output.files[this.assets[asset]] = {
             'logical_path': asset

--- a/tests/formatTest.js
+++ b/tests/formatTest.js
@@ -15,6 +15,8 @@ function test_general() {
                  'app_js.5018c3226e10bf313701.js');
     assert.equal(data.assets['hot_app_js.js'],
                  'app_js.5018c3226e10bf313701.js');
+    assert.equal(data.assets['app_css.js'],
+                 'app_css.291431bdd7415f9ff51d.js');
     assert.equal(data.assets['app_css.css'],
                  'app_css.291431bdd7415f9ff51d.css');
     assert.equal(data.assets['images/spinner.gif'],
@@ -28,7 +30,7 @@ function test_rails() {
 
     assert(data.assets);
     assert(data.files);
-    
+
     assert.equal(data.files['images/spinner.37348967baeae34bfa408c1f16794db1.gif']['logical_path'],
                  'images/spinner.gif')
     assert.notEqual(data.files['images/spinner.37348967baeae34bfa408c1f16794db1.gif']['logical_path'],


### PR DESCRIPTION
Currently, the plugin is assuming that we only want one file per named chunk.

It does not works with other plugins who generate multiple files per named chunk like [ExtractTextPlugin](https://github.com/webpack/extract-text-webpack-plugin).

I think it may resolve #11.