### PR TITLE
Support DllPlugin output

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,7 +60,6 @@ ManifestRevisionPlugin.prototype.parsedAssets = function (data) {
         if (item.name.indexOf('multi ') === -1 &&
             item.name.indexOf('~/') === -1 &&
             item.reasons.length === 0 &&
-            fs.lstatSync(item.name).isFile() &&
             item.hasOwnProperty('assets') &&
             item.assets.length === 1) {
 


### PR DESCRIPTION
The webpack DllPlugin spits out an item with a name like `dll vendors`. This makes it through the initial checks and then crashes on the `fs.lstatSync(item.name).isFile()` check. This way we skip over it gracefully.
