### PR TITLE
add regex option for specifying a set of file extensions

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ ManifestRevisionPlugin.prototype.parsedAssets = function (data) {
 
         if (this.options.extensionsRegex && item.name
             && (typeof item.name === 'string' || item.name instanceof String)
-            && (item.name.match(this.options.extensionsRegex)) {
+            && item.name.match(this.options.extensionsRegex)) {
 
             addCurrentItem = true;
         }

--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ var ManifestRevisionPlugin = function (output, options) {
     // Set sane defaults for any options.
     this.options.rootAssetPath = options.rootAssetPath || './';
     this.options.ignorePaths = options.ignorePaths || [];
+    this.options.extensionsRegex = options.extensionsRegex || null;
     this.options.format = options.format || 'general';
 };
 
@@ -55,6 +56,14 @@ ManifestRevisionPlugin.prototype.parsedAssets = function (data) {
 
     for (var i = 0, length = data.length; i < length; i++) {
         var item = data[i];
+        var addCurrentItem = false;
+
+        if (this.options.extensionsRegex && item.name
+            && (typeof item.name === 'string' || item.name instanceof String)
+            && (item.name.match(this.options.extensionsRegex)) {
+
+            addCurrentItem = true;
+        }
 
         // Attempt to ignore chunked assets and other unimportant assets.
         if (item.name.indexOf('multi ') === -1 &&
@@ -64,8 +73,11 @@ ManifestRevisionPlugin.prototype.parsedAssets = function (data) {
             item.hasOwnProperty('assets') &&
             item.assets.length === 1) {
 
-            var nameWithoutRoot = item.name.replace(this.options.rootAssetPath,
-                                                    '');
+            addCurrentItem = true;
+        }
+
+        if (addCurrentItem) {
+            var nameWithoutRoot = item.name.replace(this.options.rootAssetPath, '');
             var mappedAsset = this.mapAsset(nameWithoutRoot, item.assets[0]);
 
             assets[mappedAsset[0]] = mappedAsset[1];


### PR DESCRIPTION
Right now, if I have several files that are required within webpack using `file-loader`. Those are png's, svg's etc but they're not being included in the output manifest-file. To allow those files to be added to the manifest, I've added the `extensionsRegex`-option to the constructor.

Example:
```js
new ManifestRevisionPlugin(
  path.resolve(PATHS.build, 'manifest.json'),
  {
    rootAssetPath: PATHS.rootAssetPath,
    ignorePaths: [],
    extensionsRegex: /\.(jpe?g|png|gif|svg)$/i,
  }
),
```

Using this option, all assets are included appropriately in the resulting manifest-file for my particular case.

This PR might also solve [Issue #12](https://github.com/nickjj/manifest-revision-webpack-plugin/issues/12).