### PR TITLE
Fix file extension containing '?' postfix

### DIFF
--- a/format.js
+++ b/format.js
@@ -50,6 +50,9 @@ Format.prototype.mergeChunksIntoAssets = function () {
         for (var asset in assetsByChunkName[chunk]) {
             asset = assetsByChunkName[chunk][asset];
             var fileExtension = asset.split('.').slice(-1)[0];
+            if (fileExtension.indexOf('?') != -1) {
+              fileExtension = fileExtension.substr(0, fileExtension.indexOf('?'))
+            }
             var chunkWithExtension = chunk + '.' + fileExtension;
 
             output.assets[chunkWithExtension] = asset;


### PR DESCRIPTION
When the chunkhash is contained after the file extension, this plugin incorrectly contains the hash in the `chunkWithExtension` variable.

This kind of usage is in the webpack react example: https://github.com/webpack/react-starter/blob/master/make-webpack-config.js#L57

This fixes and removes the `?` postfix from the file extension.