### PR TITLE
Add flattened format

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ module.exports = {
 - `ignorePaths` is an array of paths to ignore. Path could be a string or regexp.
 - `extensionsRegex` is a regexp for assets you always want to include. Example: `/\.(jpe?g|png|gif|svg)$/i`
 - `format` allows you to pick the manifest output file format.
-  - Currently supports `general` (default), `rails` or passing in a function.
+  - Currently supports `general` (default), `rails`, `flattened` or passing in a function.
 
 If you want to use a custom function it could look like this:
 

--- a/format.js
+++ b/format.js
@@ -35,6 +35,38 @@ Format.prototype.normalizeChunks = function () {
     return output;
 };
 
+function parseChunkValue (name, value) {
+    var ext = value.split('.').slice(-1)[0];
+    return name + '.' + ext;
+};
+
+/**
+ * Assets resulting in more than a single chunk will yield an array. This function creates
+ * one entry for each of those in the resulting manifest.
+
+ * @returns {object}
+ */
+Format.prototype.flattened = function () {
+    var output = {};
+    output.assets = this.assets;
+
+    for (var chunkName in this.data.assetsByChunkName) {
+        var chunkValue = this.data.assetsByChunkName[chunkName];
+        if (typeof chunkValue === 'string') {
+            output.assets[parseChunkValue(chunkName, chunkValue)] = chunkValue;
+        } else if (Array.isArray(chunkValue)) {
+            chunkValue = chunkValue.filter(function(item) {
+                return item.indexOf('hot-update.js') === -1;
+            });
+            chunkValue.forEach(function (val) {
+                output.assets[parseChunkValue(chunkName, val)] = val;
+            });
+        }
+    }
+    output.publicPath = this.data.publicPath;
+    return output;
+};
+
 /**
  * At the end of the day the chunks are assets so combine them into the assets.
 

--- a/tests/formatTest.js
+++ b/tests/formatTest.js
@@ -37,5 +37,27 @@ function test_rails() {
                  'images/spinner.37348967baeae34bfa408c1f16794db1.gif')
 }
 
+function test_flattened() {
+    var data = format.flattened();
+
+    assert.equal(data.publicPath, 'http://localhost:2992/assets/');
+
+    assert.equal(data.assets['app_js.js'],
+                 'app_js.5018c3226e10bf313701.js');
+    assert.equal(data.assets['hot_app_js.js'],
+                 'app_js.5018c3226e10bf313701.js');
+    assert.equal(data.assets['app_css.js'],
+                 'app_css.291431bdd7415f9ff51d.js');
+    assert.equal(data.assets['app_css.css'],
+                 'app_css.291431bdd7415f9ff51d.css');
+    assert.equal(data.assets['app_css.js'],
+                 'app_css.291431bdd7415f9ff51d.js');
+    assert.equal(data.assets['images/spinner.gif'],
+                 'images/spinner.37348967baeae34bfa408c1f16794db1.gif')
+    assert.notEqual(data.assets['images/credit-cards/visa.png'],
+                    'visa.26bcf191ee12e711aa540ba8d0c901b7.png')
+}
+
 test_general();
 test_rails();
+test_flattened();


### PR DESCRIPTION
Hi @nickjj ,
we are using flask-webpack, thanks for creating it!.
We have an entry in our webpack.config.js that points to a js file, i.e.:
```
        customers: [
            rootAssetPath + '/src/client/apps/customers.js'
        ],
```
which, at some point, requires some stylesheets, i.e.
```
require('../styles/customer/main.scss');

var app = angular.module('app', [
    'ngRoute',
    'ngResource',
    'ui.bootstrap',
    'ui.mask'
]);

```
The resulting build contains a js file which we include in one of our pages using `javascript_tag` and a css file which we also want to include in that page. The css file is built correctly but it does not show in the resulting manifest.json file, so we made this format. I'm pretty sure this does not need to be included in your package but I thought I would submit the PR just in case. Maybe you have a suggestion of how we could do this without the custom format.

Again, thanks for this and for the awesome video you made explaining how it all fits together.