### PR TITLE
Add error handling around the `fs.lstatSync` call

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,11 +65,19 @@ ManifestRevisionPlugin.prototype.parsedAssets = function (data) {
             addCurrentItem = true;
         }
 
+        try {
+          var fileType = fs.lstatSync(item.name);
+          if (fs.lstatSync(item.name).isFile()) {
+            addCurrentItem = true;
+          }
+        } catch (err) {
+          // Ignore it since it isn't a file we care about
+        }
+
         // Attempt to ignore chunked assets and other unimportant assets.
         if (item.name.indexOf('multi ') === -1 &&
             item.name.indexOf('~/') === -1 &&
             item.reasons.length === 0 &&
-            fs.lstatSync(item.name).isFile() &&
             item.hasOwnProperty('assets') &&
             item.assets.length === 1) {
 


### PR DESCRIPTION
Ran into an issue where the variable `item.name` was being set to the string `template of 204 referencing` for whatever reason, which resulted in the `fs.lstatSync` call erring out.

This PR adds some basic error handling around that call.

Sample slightly-sanitized stack trace:

``` text
111ms build modules
4ms seal
22ms optimize
10ms hashing
0ms create chunk assets
2ms additional chunk assets
1ms optimize chunk assets
0ms optimize assets
 95% emitfs.js:887
  return binding.lstat(pathModule._makeLong(path));
                 ^

Error: ENOENT: no such file or directory, lstat 'template of 204 referencing '
    at Error (native)
    at Object.fs.lstatSync (fs.js:887:18)
    at ManifestRevisionPlugin.parsedAssets (/home/marvin/projects/newproj/node_modules/manifest-revision-webpack-plugin/index.js:72:16)
    at Compiler.<anonymous> (/home/marvin/projects/newproj/node_modules/manifest-revision-webpack-plugin/index.js:160:33)
    at Compiler.applyPlugins (/home/marvin/projects/newproj/node_modules/tapable/lib/Tapable.js:26:37)
    at Watching._done (/home/marvin/projects/newproj/node_modules/webpack/lib/Compiler.js:78:17)
    at Watching.<anonymous> (/home/marvin/projects/newproj/node_modules/webpack/lib/Compiler.js:61:18)
    at Compiler.emitRecords (/home/marvin/projects/newproj/node_modules/webpack/lib/Compiler.js:282:37)
    at Watching.<anonymous> (/home/marvin/projects/newproj/node_modules/webpack/lib/Compiler.js:58:19)
    at /home/marvin/projects/newproj/node_modules/webpack/lib/Compiler.js:275:11
    at Compiler.applyPluginsAsync (/home/marvin/projects/newproj/node_modules/tapable/lib/Tapable.js:60:69)
    at Compiler.afterEmit (/home/marvin/projects/newproj/node_modules/webpack/lib/Compiler.js:272:8)
    at Compiler.<anonymous> (/home/marvin/projects/newproj/node_modules/webpack/lib/Compiler.js:267:14)
    at /home/marvin/projects/newproj/node_modules/async/lib/async.js:52:16
    at done (/home/marvin/projects/newproj/node_modules/async/lib/async.js:246:17)
    at /home/marvin/projects/newproj/node_modules/async/lib/async.js:44:16
    at /home/marvin/projects/newproj/node_modules/graceful-fs/graceful-fs.js:43:10
    at FSReqWrap.oncomplete (fs.js:82:15)
make: *** [build-assets] Error 1
```
