### PR TITLE
Updated package.json to allow webpack v2.2.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
     "walk": "^2.3.9"
   },
   "peerDependencies": {
-    "webpack": "^1.8.11"
+    "webpack": "^1.8.11 || ^2.2.0"
   }
 }


### PR DESCRIPTION
What kind of change does this PR introduce?

Dependency update

Did you add or update the examples/?
No

Summary

Allow webpack 2.2.0 without peer dep warning

Does this PR introduce a breaking change?

No

Other information