### PR TITLE
Add prefetch option and default to false

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ var ManifestRevisionPlugin = function (output, options) {
     this.options.ignorePaths = options.ignorePaths || [];
     this.options.extensionsRegex = options.extensionsRegex || null;
     this.options.format = options.format || 'general';
+    this.options.prefetch = options.prefetch || false;
 };
 
 /**
@@ -173,7 +174,9 @@ ManifestRevisionPlugin.prototype.apply = function (compiler) {
     options.errorDetails = false;
     options.chunkOrigins = false;
 
-    self.walkAndPrefetchAssets(compiler);
+    if (this.options.prefetch) {
+      self.walkAndPrefetchAssets(compiler);
+    }
 
     compiler.plugin('done', function (stats) {
         var data = stats.toJson(options);


### PR DESCRIPTION
Prefetching all assets causes problems for projects that are being gradually migrated to webpack. Users may want the ability to push webpack to production bits at a time for easier code review and to minimize the impact of any errors. Unconverted files may live in directories with other files that are being included in the compilation process, and if prefetching is enabled, they will throw errors as the compiler parses them.

Making the prefetching an opt-in option allows for a default of parsing only the entry files and their dependencies, rather than all files in any included directories.