### PR TITLE
Add support for Webpack 4

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,7 +75,7 @@ ManifestRevisionPlugin.prototype.parsedAssets = function (data) {
         // Attempt to ignore chunked assets and other unimportant assets.
         if (isFile &&
             item.name.indexOf('~/') === -1 &&
-            item.reasons.length === 0 &&
+            (item.reasons.length === 0 || item.reasons[0].type === 'prefetch') &&
             item.hasOwnProperty('assets') &&
             item.assets.length === 1) {
 


### PR DESCRIPTION
In Webpack 4 all modules added using the `webpack.PrefetchPlugin` also get a reason object explaining why the assets was added. The reason object will have a `type: "prefetch"` property indicating that the `PrefetchPlugin` added it, and potentially more reasons if the asset was also required by other modules.

All modules also have a `prefetched` property indicating whether or not it was prefetched, which we could use instead of checking `reasons`. But that would also apply to any dynamically required modules using the `webpackPrefetch` comment hint. Thus to keep the logic as close as possible to how it worked in Webpack 3 this only checks for a Webpack 4's `prefetch` reason object.