### PR TITLE
Fix webpack 4 deprecated warnings

### DIFF
--- a/index.js
+++ b/index.js
@@ -175,7 +175,7 @@ ManifestRevisionPlugin.prototype.apply = function (compiler) {
 
     self.walkAndPrefetchAssets(compiler);
 
-    compiler.plugin('done', function (stats) {
+    function done(stats) {
         var data = stats.toJson(options);
         var parsedAssets = self.parsedAssets(data.modules);
         var outputData = null;
@@ -194,7 +194,15 @@ ManifestRevisionPlugin.prototype.apply = function (compiler) {
         }
 
         fs.writeFileSync(output, String(outputData));
-    });
+    };
+
+    if (compiler.hooks) {
+        var plugin = {name: 'ManifestRevisionPlugin'}
+        compiler.hooks.done.tap(plugin, done.bind(self))
+    } 
+    else {
+        compiler.plugin('done', done.bind(self))
+    }
 };
 
 module.exports = ManifestRevisionPlugin;

--- a/index.js
+++ b/index.js
@@ -146,7 +146,7 @@ ManifestRevisionPlugin.prototype.walkAndPrefetchAssets = function (compiler) {
             file: function (root, fileStat, next) {
                 var assetPath = path.resolve(root, fileStat.name);
                 if (self.isSafeToTrack(assetPath)) {
-                    compiler.apply(new webpack.PrefetchPlugin(assetPath));
+                    new webpack.PrefetchPlugin(assetPath).apply(compiler);
                 }
 
                 next();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,21 @@
+{
+  "name": "manifest-revision-webpack-plugin",
+  "version": "0.4.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "foreachasync": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/foreachasync/-/foreachasync-3.0.0.tgz",
+      "integrity": "sha1-VQKYfchxS+M5IJfzLgBxyd7gfPY="
+    },
+    "walk": {
+      "version": "2.3.14",
+      "resolved": "https://registry.npmjs.org/walk/-/walk-2.3.14.tgz",
+      "integrity": "sha512-5skcWAUmySj6hkBdH6B6+3ddMjVQYH5Qy9QGbPmN8kVmLteXk+yVXg+yfk1nbX30EYakahLrr8iPcCxJQSCBeg==",
+      "requires": {
+        "foreachasync": "^3.0.0"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Hi @nickjj!

Fix warnings in console:

```
DeprecationWarning: Tapable.apply is deprecated. Call apply on the plugin directly instead
DeprecationWarning: Tapable.plugin is deprecated. Use new API on `.hooks` instead
```

